### PR TITLE
feat: add remove profile picture button to account settings #issue1

### DIFF
--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -37,6 +37,10 @@ export default {
         h += `<div style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
             h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
             h += `</div>`;
+            // show remove button only if user has a profile picture
+            if(window.user?.profile?.picture) {
+                h += `<button class="button remove-profile-picture" style="margin-top: 10px;">${i18n('remove_profile_picture')}</button>`;
+            }
         h += `</div>`;
 
         // change password button
@@ -149,6 +153,24 @@ export default {
                 selectable_body: false,
             });    
         })
+
+        $el_window.find('.remove-profile-picture').on('click', function (e) {
+            console.log('Removing profile picture...');
+            
+            // Clear the profile picture from user's profile
+            update_profile(window.user.username, {picture: null});
+            
+            // Update the profile picture display to default avatar
+            const defaultAvatar = window.icons['profile.svg'];
+            $el_window.find('.profile-picture').css('background-image', `url('${defaultAvatar}')`);
+            $('.profile-image').css('background-image', `url('${defaultAvatar}')`);
+            $('.profile-image').removeClass('profile-image-has-picture');
+            
+            // Show the remove button (if hidden)
+            $el_window.find('.remove-profile-picture').show();
+            
+            console.log('Profile picture removed successfully');
+        });
 
         $el_window.on('file_opened', async function(e){
             let selected_file = Array.isArray(e.detail) ? e.detail[0] : e.detail;

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -238,6 +238,7 @@ const en = {
         refresh: 'Refresh',
         release_address_confirmation: `Are you sure you want to release this address?`,
         remove_from_taskbar:'Remove from Taskbar',
+        remove_profile_picture: 'Remove Profile Picture',
         rename: 'Rename',
         repeat: 'Repeat',
         replace: 'Replace',


### PR DESCRIPTION
"Fixes #1"
Added a remove profile picture button to the account settings; the issue was that a user could upload a picture as profile pic but there was no option to remove it 
![issue1](https://github.com/user-attachments/assets/65b384df-efac-4f01-b599-424b038e3e44)

I made this feature  a week ago so I did not know we had to  take a before picture until this week but I have an after picture 
walk through of the code:

https://github.com/user-attachments/assets/ff90616b-3f31-4eab-b772-76a71904449f






