### PR TITLE
Feature/toolbar auto hide

### DIFF
--- a/doc/scratch.md
+++ b/doc/scratch.md
@@ -454,3 +454,178 @@ Add a "Set as Desktop Background" context menu option that appears when users ri
 - **Impact**: Improves convenience for users who want to customize desktop
 - **Risk**: Low - isolated change to context menu, reuses existing desktop background functionality
 - **Dependencies**: None - uses existing APIs and functions
+
+## 2025--XX: Auto-Hide Top Toolbar Feature
+
+### Feature Description
+Implement an auto-hide feature for the top toolbar that hides it after 2 seconds of inactivity and shows it again when the mouse moves near the top edge of the screen (within 50px).
+
+### Current Behavior
+- Top toolbar is always visible
+- Toolbar occupies screen space continuously (30px height)
+- No option to hide or minimize toolbar
+
+### Expected Behavior
+- Toolbar automatically hides after 2 seconds of mouse inactivity
+- Toolbar reappears when mouse moves within 50px of top screen edge
+- Smooth fade/slide animation for hiding and showing
+- Optional setting to toggle auto-hide on/off (default: off for backwards compatibility)
+- Maintains full functionality when visible
+
+### Step-by-Step Implementation Plan
+
+#### Step 1: Add CSS Classes for Auto-Hide Animation
+- **File**: `src/gui/src/css/style.css`
+- **Location**: After `.toolbar` class definition (around line 1752)
+- **Action**: Add CSS classes for hidden state and transitions
+  - `.toolbar-auto-hide-hidden` - class to hide toolbar
+  - CSS transition for smooth animation (opacity and transform)
+  - Ensure toolbar maintains functionality when transitioning
+
+#### Step 2: Add User Preference for Auto-Hide
+- **File**: `src/gui/src/globals.js`
+- **Location**: In `window.user_preferences` defaults (around line 98-102)
+- **Action**: Add default preference: `toolbar_auto_hide: false`
+- **File**: `src/gui/src/UI/UIDesktop.js`
+- **Location**: In user preferences loading section (around line 709-713)
+- **Action**: Load `toolbar_auto_hide` preference from KV store
+
+#### Step 3: Add Auto-Hide Logic to UIDesktop
+- **File**: `src/gui/src/UI/UIDesktop.js`
+- **Location**: After toolbar HTML insertion (around line 1146)
+- **Action**: 
+  - Initialize auto-hide state variables
+  - Set up mouse move tracking
+  - Set up inactivity timeout (2 seconds)
+  - Implement show/hide functions with smooth animations
+  - Check mouse proximity to top edge (50px threshold)
+
+#### Step 4: Add Settings UI Toggle (Optional but Recommended)
+- **File**: `src/gui/src/UI/Settings/UITabPersonalization.js` or appropriate settings tab
+- **Action**: Add checkbox/toggle to enable/disable auto-hide feature
+- **Action**: Save preference using `window.mutate_user_preferences()`
+
+### Files That Will Be Modified
+
+1. **`src/gui/src/css/style.css`**
+   - **Purpose**: Add CSS for auto-hide animation
+   - **Changes**: 
+     - Add `.toolbar-auto-hide-hidden` class with transform/opacity
+     - Add transition properties for smooth animation
+     - Ensure z-index and positioning work correctly when hidden
+
+2. **`src/gui/src/globals.js`**
+   - **Purpose**: Add default preference value
+   - **Changes**: Add `toolbar_auto_hide: false` to default preferences
+
+3. **`src/gui/src/UI/UIDesktop.js`**
+   - **Purpose**: Implement auto-hide logic
+   - **Changes**:
+     - Load `toolbar_auto_hide` preference
+     - Add mouse tracking event listeners
+     - Add timeout management for inactivity
+     - Add show/hide functions
+     - Conditional logic to only activate if preference is enabled
+
+4. **`src/gui/src/UI/Settings/UITabPersonalization.js`** (Optional)
+   - **Purpose**: Add UI toggle for feature
+   - **Changes**: Add checkbox/toggle control
+
+5. **`src/gui/src/helpers/update_mouse_position.js`** (May need to check)
+   - **Purpose**: Verify mouse position tracking is available
+   - **Action**: Check if `window.mouseY` is already being tracked
+
+### Functions That Will Be Modified/Created
+
+1. **New Functions in `UIDesktop.js`**:
+
+   a. **`init_toolbar_auto_hide()`**
+      - **Purpose**: Initialize auto-hide functionality
+      - **Logic**:
+        ```javascript
+        function init_toolbar_auto_hide() {
+            if (!window.user_preferences.toolbar_auto_hide) return;
+            
+            let hideTimeout;
+            let isHidden = false;
+            const toolbar = $('.toolbar');
+            const HIDE_DELAY = 2000; // 2 seconds
+            const SHOW_THRESHOLD = 50; // 50px from top
+            
+            function hideToolbar() {
+                if (!isHidden) {
+                    toolbar.addClass('toolbar-auto-hide-hidden');
+                    isHidden = true;
+                }
+            }
+            
+            function showToolbar() {
+                if (isHidden) {
+                    toolbar.removeClass('toolbar-auto-hide-hidden');
+                    isHidden = false;
+                }
+                clearTimeout(hideTimeout);
+                hideTimeout = setTimeout(hideToolbar, HIDE_DELAY);
+            }
+            
+            // Track mouse movement
+            $(document).on('mousemove', function(e) {
+                if (e.clientY <= SHOW_THRESHOLD) {
+                    showToolbar();
+                } else {
+                    // Reset hide timeout if toolbar is visible
+                    if (!isHidden) {
+                        clearTimeout(hideTimeout);
+                        hideTimeout = setTimeout(hideToolbar, HIDE_DELAY);
+                    }
+                }
+            });
+            
+            // Initial timeout
+            hideTimeout = setTimeout(hideToolbar, HIDE_DELAY);
+        }
+        ```
+
+   b. **Toolbar event handlers**
+      - When toolbar buttons are hovered/clicked, keep toolbar visible
+      - Reset timeout on toolbar interaction
+
+### Implementation Details
+
+#### CSS Animation Approach
+- Use `transform: translateY(-100%)` to slide up
+- Use `opacity: 0` for fade effect
+- Transition duration: ~300ms for smooth animation
+- Use `pointer-events: none` when hidden to prevent interaction issues
+
+#### Mouse Tracking
+- Use existing `window.mouseY` if available from `update_mouse_position.js`
+- Or use `$(document).mousemove()` event with `e.clientY`
+- Check `e.clientY <= 50` to show toolbar
+
+#### Timeout Management
+- Clear existing timeout before setting new one
+- Handle edge cases (window focus, mouse leaving window, etc.)
+
+#### Backwards Compatibility
+- Default to `toolbar_auto_hide: false` so existing users are not affected
+- Feature only activates if explicitly enabled
+
+### Testing Checklist
+1. ✅ Toolbar remains visible by default (backwards compatibility)
+2. ✅ Enable auto-hide in settings (if implemented)
+3. ✅ Toolbar hides after 2 seconds of inactivity
+4. ✅ Toolbar shows when mouse moves near top edge (within 50px)
+5. ✅ Smooth animation when hiding/showing
+6. ✅ Toolbar buttons remain functional when visible
+7. ✅ Toolbar stays visible when hovering over it
+8. ✅ Toolbar stays visible when clicking toolbar buttons
+9. ✅ Preference persists across page refresh
+10. ✅ Works on different screen sizes
+11. ✅ Works when window loses focus and regains focus
+
+### Implementation Priority
+- **Medium**: User experience enhancement
+- **Impact**: Improves screen space utilization
+- **Risk**: Low - isolated change, backwards compatible (default off)
+- **Dependencies**: None - uses existing mouse tracking and preferences system

--- a/src/gui/src/UI/Settings/UITabPersonalization.js
+++ b/src/gui/src/UI/Settings/UITabPersonalization.js
@@ -48,6 +48,15 @@ export default {
                     <option value="show">${i18n('clock_visible_show')}</option>
                 </select>
             </div>
+            <div class="settings-card">
+                <label style="display: flex; align-items: center;">
+                    <input type="checkbox" class="toolbar-auto-hide-toggle" style="margin-right: 10px;">
+                    <div style="flex-grow: 1;">
+                        <strong>${i18n('toolbar_auto_hide')}</strong>
+                        <p style="margin-top: 5px; margin-bottom: 0; font-size: 12px; opacity: 0.8;">${i18n('toolbar_auto_hide_description')}</p>
+                    </div>
+                </label>
+            </div>
             <div class="settings-card" style="display: block; height: auto;">
                 <strong style="margin: 15px 0 30px; display: block;">${i18n('menubar_style')}</strong>
                 <div style="flex-grow:1; margin-top: 10px;">
@@ -101,6 +110,20 @@ export default {
         });
 
         window.change_clock_visible();
+
+        // Load and set toolbar auto-hide preference
+        const currentValue = window.user_preferences?.toolbar_auto_hide || false;
+        $el_window.find('.toolbar-auto-hide-toggle').prop('checked', currentValue);
+
+        // Handle toolbar auto-hide toggle change
+        $el_window.find('.toolbar-auto-hide-toggle').on('change', function(e) {
+            const isEnabled = $(this).prop('checked');
+            window.mutate_user_preferences({
+                toolbar_auto_hide: isEnabled
+            });
+            // Reload page to apply changes (since auto-hide is initialized on page load)
+            window.location.reload();
+        });
 
         puter.kv.get('menubar_style').then(async (val) => {
             if(val === 'system' || !val){

--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -723,6 +723,52 @@ async function UIDesktop(options){
         }
 
         window.update_user_preferences(user_preferences);
+        
+        // Initialize toolbar auto-hide after preferences are loaded
+        if (user_preferences.toolbar_auto_hide) {
+            const toolbar = $('.toolbar');
+            let hideTimeout;
+            const HIDE_DELAY = 2000; // 2 seconds of inactivity
+            const SHOW_THRESHOLD = 50; // 50px from top to show toolbar
+            
+            function hideToolbar() {
+                toolbar.addClass('toolbar-auto-hide-hidden');
+            }
+            
+            function showToolbar() {
+                toolbar.removeClass('toolbar-auto-hide-hidden');
+                clearTimeout(hideTimeout);
+            }
+            
+            function resetHideTimeout() {
+                clearTimeout(hideTimeout);
+                hideTimeout = setTimeout(hideToolbar, HIDE_DELAY);
+            }
+            
+            // Show toolbar when mouse enters toolbar area
+            toolbar.on('mouseenter', function() {
+                showToolbar();
+            });
+            
+            // Track ALL mouse movement for inactivity detection
+            $(document).on('mousemove', function(e) {
+                // Always show toolbar when mouse is near top edge
+                if (e.clientY <= SHOW_THRESHOLD) {
+                    showToolbar();
+                } else {
+                    // Reset timeout on any mouse movement (inactivity detection)
+                    resetHideTimeout();
+                }
+            });
+            
+            // Reset timeout on mouse click anywhere
+            $(document).on('mousedown click', function() {
+                resetHideTimeout();
+            });
+            
+            // Initial hide after 2 seconds of inactivity
+            hideTimeout = setTimeout(hideToolbar, HIDE_DELAY);
+        }
     });
 
     // Append to <body>
@@ -1148,42 +1194,6 @@ async function UIDesktop(options){
 
     // prepend toolbar to desktop
     $(ht).insertBefore(el_desktop);
-
-    // Initialize toolbar auto-hide if enabled
-    if (window.user_preferences.toolbar_auto_hide) {
-        const toolbar = $('.toolbar');
-        let hideTimeout;
-        const SHOW_THRESHOLD = 50; // 50px from top to show toolbar
-        
-        function hideToolbar() {
-            toolbar.addClass('toolbar-auto-hide-hidden');
-        }
-        
-        function showToolbar() {
-            toolbar.removeClass('toolbar-auto-hide-hidden');
-            clearTimeout(hideTimeout);
-        }
-        
-        // Hide toolbar when mouse leaves toolbar area
-        toolbar.on('mouseleave', function() {
-            hideTimeout = setTimeout(hideToolbar, 2000); // 2 second delay after leaving
-        });
-        
-        // Show toolbar when mouse enters toolbar area
-        toolbar.on('mouseenter', function() {
-            showToolbar();
-        });
-        
-        // Show toolbar when mouse moves near top edge of screen
-        $(document).on('mousemove', function(e) {
-            if (e.clientY <= SHOW_THRESHOLD) {
-                showToolbar();
-            }
-        });
-        
-        // Initial hide after 2 seconds if mouse is not on toolbar
-        hideTimeout = setTimeout(hideToolbar, 2000);
-    }
 
     // notification container
     $('body').append(`<div class="notification-container"><div class="notifications-close-all">${i18n('close_all')}</div></div>`);

--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -706,10 +706,14 @@ async function UIDesktop(options){
     }
 
     // update local user preferences
+    const toolbar_auto_hide_value = await puter.kv.get('user_preferences.toolbar_auto_hide');
     const user_preferences = {
         show_hidden_files: JSON.parse(await puter.kv.get('user_preferences.show_hidden_files')),
         language: await puter.kv.get('user_preferences.language'),
         clock_visible: await puter.kv.get('user_preferences.clock_visible'),
+        toolbar_auto_hide: toolbar_auto_hide_value !== null && toolbar_auto_hide_value !== undefined 
+            ? JSON.parse(toolbar_auto_hide_value) 
+            : false,
     };
 
     // update default apps
@@ -1144,6 +1148,42 @@ async function UIDesktop(options){
 
     // prepend toolbar to desktop
     $(ht).insertBefore(el_desktop);
+
+    // Initialize toolbar auto-hide if enabled
+    if (window.user_preferences.toolbar_auto_hide) {
+        const toolbar = $('.toolbar');
+        let hideTimeout;
+        const SHOW_THRESHOLD = 50; // 50px from top to show toolbar
+        
+        function hideToolbar() {
+            toolbar.addClass('toolbar-auto-hide-hidden');
+        }
+        
+        function showToolbar() {
+            toolbar.removeClass('toolbar-auto-hide-hidden');
+            clearTimeout(hideTimeout);
+        }
+        
+        // Hide toolbar when mouse leaves toolbar area
+        toolbar.on('mouseleave', function() {
+            hideTimeout = setTimeout(hideToolbar, 2000); // 2 second delay after leaving
+        });
+        
+        // Show toolbar when mouse enters toolbar area
+        toolbar.on('mouseenter', function() {
+            showToolbar();
+        });
+        
+        // Show toolbar when mouse moves near top edge of screen
+        $(document).on('mousemove', function(e) {
+            if (e.clientY <= SHOW_THRESHOLD) {
+                showToolbar();
+            }
+        });
+        
+        // Initial hide after 2 seconds if mouse is not on toolbar
+        hideTimeout = setTimeout(hideToolbar, 2000);
+    }
 
     // notification container
     $('body').append(`<div class="notification-container"><div class="notifications-close-all">${i18n('close_all')}</div></div>`);

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -1748,7 +1748,14 @@ label {
     justify-content: flex-end;
     align-content: center;
     flex-wrap: wrap;
-    padding-right: 10px
+    padding-right: 10px;
+    transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+}
+
+.toolbar-auto-hide-hidden {
+    transform: translateY(-100%);
+    opacity: 0;
+    pointer-events: none;
 }
 
 .show-desktop-btn {

--- a/src/gui/src/globals.js
+++ b/src/gui/src/globals.js
@@ -99,6 +99,7 @@ if (window.user_preferences === null) {
         show_hidden_files: false,
         language: navigator.language.split("-")[0] || navigator.userLanguage || 'en',
         clock_visible: 'auto',
+        toolbar_auto_hide: false,
     }
 }
 

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -270,6 +270,8 @@ const en = {
         settings: "Settings",
         set_new_password: "Set New Password",
         share: "Share",
+        toolbar_auto_hide: "Auto-hide Toolbar",
+        toolbar_auto_hide_description: "Automatically hide the toolbar after 2 seconds of inactivity. Move mouse near top edge to show it again.",
         share_to: "Share to",
         share_with: "Share with:",
         set_as_desktop_background: "Set as Desktop Background",

--- a/src/puter-js/src/modules/KV.js
+++ b/src/puter-js/src/modules/KV.js
@@ -10,6 +10,7 @@ const gui_cache_keys = [
     'user_preferences.show_hidden_files',
     'user_preferences.language',
     'user_preferences.clock_visible',
+    'user_preferences.toolbar_auto_hide',
     'has_seen_welcome_window',
 ];
 


### PR DESCRIPTION
fixes #21 
Add Toolbar Auto-Hide Feature
### Summary
Adds an auto-hide feature for the top toolbar that hides after 2 seconds of inactivity and reappears when the mouse moves near the top edge.
Changes
CSS animations: Smooth fade/slide transitions for show/hide
- Inactivity detection: Tracks mouse movement and hides toolbar after 2 seconds of inactivity
- Show on proximity: Toolbar reappears when mouse moves within 50px of top edge
- Settings toggle: Added checkbox in Settings > Personalization to enable/disable the feature
- User preference: Persisted across sessions via KV store
- Backwards compatible: Defaults to false (disabled) so existing users are unaffected
 
### Behavior

- Hides after 2 seconds of mouse inactivity anywhere on the page
- Shows immediately when mouse moves within 50px of top edge
- Shows when mouse enters toolbar area
- Smooth 300ms fade/slide animation
- Preference persists across sessions

### Before Picture 
![issue#18Before ](https://github.com/user-attachments/assets/7bf7f9bd-f357-48a3-9f1f-cbdb0e1c59ce)
### After picture
![issue#18After](https://github.com/user-attachments/assets/3bd4da4b-53a2-4605-a2b1-c1aae2f75e03)

### Video description 
https://cap.so/s/c60dn1mv7wvc4pb

