### PR TITLE
Fix/window close minimize no focus incorrect

### DIFF
--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -1620,7 +1620,9 @@ async function UIWindow(options) {
     // --------------------------------------------------------
     // Minimize button
     // --------------------------------------------------------
-    $(`#window-${win_id} > .window-head > .window-minimize-btn`).click(function () {
+    $(`#window-${win_id} > .window-head > .window-minimize-btn`).click(function (event) {
+        event.stopPropagation();
+        event.preventDefault();
         $(el_window).hideWindow();
     })
 

--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -1609,7 +1609,9 @@ async function UIWindow(options) {
     // --------------------------------------------------------
     // Close button
     // --------------------------------------------------------
-    $(`#window-${win_id} > .window-head > .window-close-btn`).click(function () {
+    $(`#window-${win_id} > .window-head > .window-close-btn`).click(function (event) {
+        event.stopPropagation();
+        event.preventDefault();
         $(el_window).close({
             shrink_to_target: options.on_close_shrink_to_target
         });

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -1225,6 +1225,13 @@ window.initgui = async function(options){
         if($(e.target).hasClass('taskbar') || $(e.target).closest('.taskbar').length > 0)
             return;
 
+        // if close or minimize button is clicked, don't activate window
+        // This prevents the window from coming to foreground when closing/minimizing
+        if($(e.target).hasClass('window-close-btn') || $(e.target).closest('.window-close-btn').length > 0)
+            return;
+        if($(e.target).hasClass('window-minimize-btn') || $(e.target).closest('.window-minimize-btn').length > 0)
+            return;
+
         // if mouse is clicked on a window, activate it
         if(window.mouseover_window !== undefined){
             // if popover clicked on, don't activate window. This is because if an app 


### PR DESCRIPTION
fixes #58 
### Problem
Clicking the close or minimize button on a background window brought it to the foreground before the action executed, disrupting workflow.
### Solution

- Prevented the window from focusing when clicking the close/minimize buttons using two approaches:
- Event propagation control: Added event.stopPropagation() and event.preventDefault() to the close and minimize button click handlers to stop the event from bubbling to parent handlers.
- Global handler exclusion: Updated the global mousedown handler to exclude clicks on close/minimize buttons, providing a fallback if events still bubble.

### Changes Made

- src/gui/src/UI/UIWindow.js: Added event propagation control to close and minimize button handlers
- src/gui/src/initgui.js: Added checks to exclude close/minimize buttons from the global window activation logic


### Before 

https://github.com/user-attachments/assets/2e8e3ac5-f4fe-48b1-b9fa-0c600b743e8f

### After 

https://github.com/user-attachments/assets/5028ad91-8910-4009-979f-cf50bf8568a8

### Video Description
https://cap.so/s/4w47frcwnqxgwb4

